### PR TITLE
reload was able to spawn multiple NSTimer instances

### DIFF
--- a/KIImagePager/KIImagePager/KIImagePager.m
+++ b/KIImagePager/KIImagePager/KIImagePager.m
@@ -362,6 +362,9 @@
 {
     if (_slideshowTimeInterval > 0) {
         if ([(NSArray *)[_dataSource arrayWithImages:self] count] > 1) {
+            if(_slideshowTimer){
+                [_slideshowTimer invalidate];
+            }
             _slideshowTimer = [NSTimer scheduledTimerWithTimeInterval:_slideshowTimeInterval target:self selector:@selector(slideshowTick:) userInfo:nil repeats:YES];
         }
     }


### PR DESCRIPTION
If you have to reload your data a couple of times you will notice the ticks speed up. This happens because in the current implementation you spawn an NSTimer each time reload is visited, which in turn can produce many instances of NSTimer which all fire tick events.